### PR TITLE
rewrite Dockerfile with base Python3.8:slim

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,22 @@ In the case that freely installing dependencies in the local computer is not pos
     ```
     $ python3 -m pip install .
     ```
-## Installing using Docker
-This Dockerfile specifies a base image (`continuumio/miniconda3:latest`), updates conda, installs the necessary dependencies, and copies the `mtbi_meeg` package code into the container. It also sets the working directory and specifies the default command to run when the container starts.
+## Build and run using Docker
 
-1. Build the Docker image: Run the command `docker build -t mtbi_meeg . ` to build the Docker image. This will create a new image named `mtbi_meeg` based on the Dockerfile.
+Requirements: [docker](https://docs.docker.com/get-docker/)
 
-2. Run the Docker container: Run the command `docker run -it mtbi_meeg` to start the container and run your package. This will start a new container based on the my_package image and run the default command specified in the Dockerfile.
+Build the Docker image
+```bash
+docker build -t mtbi_meeg .
+``` 
+This will create a new image named `mtbi_meeg` based on the `Dockerfile` in the project root folder.
+
+Run Docker container in an interactive mode with
+```bash
+docker run -it mtbi_meeg
+``` 
+
+TODO: Volume to persist configs and data?
 
 ## Getting started: config_common and system_check
 


### PR DESCRIPTION
Here's an alternative Dockerfile using Python3.8:slim as the base image. The build stage takes about a minute.

Also, I modified it so that the continer will run as non-root. This is a security best practice but requires some trickery. Not strictly necessary here but added if you're not familiar with it and interested in checking it out. 

Updated the README.md accordingly.

Big thing missing: the Docker container doesn't at the moment have a way to persist data (created results, configuration files, etc.), that is, all files created inside container will be destroyed when the container is stopped. This is usually done via volumes, are you familiar with those? However, if you are struggling with time and don't want to delve deeper into Docker at the moment, it is in my opinion fine to remove the Dockerfile and the Docker section from README.md and add it later if it seems like something that is needed.

